### PR TITLE
Add macOS runtime support (skip unavailable mesh shaders and ray tracing)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,22 +101,41 @@ int main(int argc, char** argv)
   };
   vkSetup.deviceExtensions.emplace_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);  // for vk_radix_sort (vrdx)
   vkSetup.deviceExtensions.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+#ifdef __APPLE__
+  // These extensions are not supported by MoltenVK - make them optional on macOS
+  vkSetup.deviceExtensions.emplace_back(VK_EXT_MESH_SHADER_EXTENSION_NAME, &meshFeaturesEXT, false);
+  vkSetup.deviceExtensions.emplace_back(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, &fragFeaturesKHR, false);
+  vkSetup.deviceExtensions.emplace_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, &baryFeaturesKHR, false);
+#else
   vkSetup.deviceExtensions.emplace_back(VK_EXT_MESH_SHADER_EXTENSION_NAME, &meshFeaturesEXT, true);
   vkSetup.deviceExtensions.emplace_back(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, &fragFeaturesKHR, true);
   vkSetup.deviceExtensions.emplace_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, &baryFeaturesKHR, true);
+#endif
   vkSetup.deviceExtensions.emplace_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);  // for ImGui
 
   // Activate the ray tracing extension
   VkPhysicalDeviceAccelerationStructureFeaturesKHR accelFeature = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR};
+#ifdef __APPLE__
+  vkSetup.deviceExtensions.emplace_back(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME, &accelFeature, false);  // Optional on macOS
+#else
   vkSetup.deviceExtensions.emplace_back(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME, &accelFeature, true);  // To build acceleration structures
+#endif
   VkPhysicalDeviceRayTracingPipelineFeaturesKHR rtPipelineFeature = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR};
   vkSetup.deviceExtensions.emplace_back(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME, &rtPipelineFeature, false);  // To use vkCmdTraceRaysKHR
+#ifdef __APPLE__
+  vkSetup.deviceExtensions.emplace_back(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME, nullptr, false);  // Optional on macOS
+#else
   vkSetup.deviceExtensions.emplace_back(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);  // Required by ray tracing pipeline
+#endif
 
   VkPhysicalDeviceShaderClockFeaturesKHR clockFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR};
+#ifdef __APPLE__
+  vkSetup.deviceExtensions.emplace_back(VK_KHR_SHADER_CLOCK_EXTENSION_NAME, &clockFeatures, false);  // Optional on macOS
+#else
   vkSetup.deviceExtensions.emplace_back(VK_KHR_SHADER_CLOCK_EXTENSION_NAME, &clockFeatures);
+#endif
 
   VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV serFeatures = {
       .sType                       = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV,

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -28,7 +28,12 @@ VramDataParameters    prmData{};
 RtxVramDataParameters prmRtxData{};
 
 // no reset function on purpose
+// On macOS with MoltenVK, mesh shaders are not supported, so default to vertex shader pipeline
+#ifdef __APPLE__
+uint32_t            prmSelectedPipeline = PIPELINE_VERT;
+#else
 uint32_t            prmSelectedPipeline = PIPELINE_MESH;
+#endif
 shaderio::FrameInfo prmFrame{};
 RenderParameters    prmRender{};
 RasterParameters    prmRaster{};

--- a/src/splat_set_vk.cpp
+++ b/src/splat_set_vk.cpp
@@ -425,9 +425,11 @@ void SplatSetVk::initDataBuffers(SplatSet& splatSet)
   VkMemoryBarrier barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
   barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
   barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-  vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-                       VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,
-                       0, 1, &barrier, 0, NULL, 0, NULL);
+  VkPipelineStageFlags dstStages = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+#ifndef __APPLE__
+  dstStages |= VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT;
+#endif
+  vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_2_TRANSFER_BIT, dstStages, 0, 1, &barrier, 0, NULL, 0, NULL);
 
   m_app->submitAndWaitTempCmdBuffer(cmd);
 

--- a/src/splat_sorter_async.cpp
+++ b/src/splat_sorter_async.cpp
@@ -131,7 +131,12 @@ bool SplatSorterAsync::innerSort()
   auto compare = [&](size_t i, size_t j) { return distances[i] > distances[j]; };
 
   // Sorting the array with respect to distance keys
+#if defined(__APPLE__)
+  // Apple clang doesn't support std::execution::par_unseq
+  std::sort(m_indices.begin(), m_indices.end(), compare);
+#else
   std::sort(std::execution::par_unseq, m_indices.begin(), m_indices.end(), compare);
+#endif
 
   m_profiler->asyncEndSection(timer);
 


### PR DESCRIPTION
## Summary

This PR adds macOS runtime support for vk_gaussian_splatting by gracefully handling unavailable Vulkan extensions (mesh shaders, ray tracing) on MoltenVK.

### Changes

- **Mesh shader pipeline guards** (`src/gaussian_splatting.cpp`): Skip mesh shader pipeline creation on macOS with `#ifndef __APPLE__`
- **RTX acceleration structure guards** (`src/gaussian_splatting.cpp`): Skip ray tracing initialization/deinitialization on macOS
- **Pipeline barrier guards** (`src/gaussian_splatting.cpp`, `src/splat_set_vk.cpp`): Conditionally include `VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT`
- **Push constant guards** (`src/gaussian_splatting.cpp`): Conditionally include `VK_SHADER_STAGE_MESH_BIT_EXT`
- **Optional extensions** (`src/main.cpp`): Make mesh shader, ray tracing, and other unavailable extensions optional on macOS
- **Default pipeline** (`src/parameters.cpp`): Default to `PIPELINE_VERT` on macOS since mesh shaders unavailable
- **Parallel execution fallback** (`src/splat_sorter_async.cpp`): Fallback for Apple clang lacking `std::execution::par_unseq`
- **VMA API version** (`src/gaussian_splatting.cpp`): Use `VK_API_VERSION_1_2` for VMA on macOS

### Testing

Tested on:
- macOS 15.x (Apple Silicon M-series)
- MoltenVK 1.4.0
- Vulkan SDK 1.4.x

Successfully built and ran with the vertex shader rendering pipeline.

### Notes

- All changes are guarded with `#ifdef __APPLE__` or `#ifndef __APPLE__` to avoid affecting other platforms
- The application falls back to vertex shader pipeline when mesh shaders are unavailable
- Ray tracing features are disabled on macOS where acceleration structure extensions are unavailable

### Related

This PR depends on nvpro_core2 macOS support: https://github.com/nvpro-samples/nvpro_core2/pull/12