### PR TITLE
Small changes to sync with nvpro_core2

### DIFF
--- a/src/camera_set.h
+++ b/src/camera_set.h
@@ -176,7 +176,7 @@ private:
     camera.ctr  = nvuCam.ctr;
     camera.up   = nvuCam.up;
     camera.fov  = nvuCam.fov;
-    camera.clip = nvuCam.clip;
+    camera.clip = nvuCam.nearFar;
     return camera;
   }
 
@@ -188,7 +188,7 @@ private:
         .ctr  = nvuCam.ctr,
         .up   = nvuCam.up,
         .fov  = nvuCam.fov,
-        .clip = nvuCam.clip,
+        .clip = nvuCam.nearFar,
     };
   }
 
@@ -200,7 +200,7 @@ private:
         .ctr  = camera.ctr,
         .up   = camera.up,
         .fov  = camera.fov,
-        .clip = camera.clip,
+        .nearFar = camera.clip,
     };
   }
 };

--- a/src/gaussian_splatting_ui.cpp
+++ b/src/gaussian_splatting_ui.cpp
@@ -54,7 +54,7 @@ GaussianSplattingUI::GaussianSplattingUI(nvutils::ProfilerManager*   profilerMan
                               [&](const nvutils::ParameterBase* const) {
                                 if(m_app)
                                 {
-                                  m_app->screenShot(m_screenshotFilename);
+                                  m_app->saveScreenShot(m_screenshotFilename);
                                 }
                               }},
                          {".png"}, &m_screenshotFilename);


### PR DESCRIPTION
When building vk_gaussian_splatting on Ubuntu 24.04 I had some problems that were solved by checking out to https://github.com/nvpro-samples/nvpro_core2/commit/a581d30e5e22cf4257a2d45046ee9eb84820824e.
I only had to modify a couple of method calls to make the sync. Feel free to integrate or ignore as preferred :D

NOTE: Only tested on Ubuntu 24.04