### PR TITLE
Build and run on AMD RDNA4 / RADV (Linux, `-DUSE_DLSS=OFF`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ set_property(TARGET spz PROPERTY FOLDER "ThirdParty")
 # Source files for this project
 #
 file(GLOB SOURCE_FILES src/*.*)
+# DLSS sources (src/dlss_*.cpp/.hpp) require the NVIDIA NGX SDK and are added
+# explicitly in the USE_DLSS block below. Exclude them from the glob so the
+# project builds with -DUSE_DLSS=OFF on platforms without NGX (e.g. AMD/RADV).
+list(FILTER SOURCE_FILES EXCLUDE REGEX "/dlss_")
 file(GLOB SHADER_FILES shaders/*.slang shaders/*.h)
 file(GLOB EXTERN_FILES 3rdparty/miniply/*.*)
 

--- a/src/gaussian_splatting.cpp
+++ b/src/gaussian_splatting.cpp
@@ -4073,6 +4073,14 @@ std::vector<BufferDumpInfo> GaussianSplatting::getAllDumpableBuffers() const
   std::vector<BufferDumpInfo> buffers;
   const VkExtent2D            gBufSize = m_gBuffers.getSize();
 
+  // G-buffers are created lazily on the first onResize(). If --saveImage is
+  // issued before any frame is rendered (e.g. as a bare command-line argument
+  // rather than inside a benchmark SEQUENCE), the color images do not exist yet
+  // and getColorImage() would dereference an empty backing store. Bail out with
+  // an empty list so callers no-op instead of crashing.
+  if(gBufSize.width == 0 || gBufSize.height == 0)
+    return buffers;
+
   // Main color buffer (always)
   buffers.push_back({m_gBuffers.getColorImage(COLOR_MAIN), prmRender.colorFormat, gBufSize, "_main"});
 

--- a/src/gaussian_splatting.h
+++ b/src/gaussian_splatting.h
@@ -207,6 +207,17 @@ protected:
     return (prmSelectedPipeline == PIPELINE_RTX || prmSelectedPipeline == PIPELINE_HYBRID || prmSelectedPipeline == PIPELINE_HYBRID_3DGUT);
   }
 
+  // DLSS enable state that is safe to query even when built without USE_DLSS
+  // (m_dlss only exists under USE_DLSS). Lets non-guarded call sites stay simple.
+  inline bool isDlssEnabled() const
+  {
+#if defined(USE_DLSS)
+    return m_dlss.isEnabled();
+#else
+    return false;
+#endif
+  }
+
   // Check if auto-focus is supported in current pipeline
   // Requires ray tracing for distance feedback (pure 3DGRT or hybrid 3DGUT+3DGRT)
   inline bool supportsAutoFocus() const

--- a/src/gaussian_splatting_ui.cpp
+++ b/src/gaussian_splatting_ui.cpp
@@ -571,7 +571,7 @@ void GaussianSplattingUI::guiDrawSummaryOverlay(ImVec2 imagePos, ImVec2 imageSiz
   {
     float       progress = 0.0f;
     std::string buf      = "1/1";
-    if(!m_dlss.isEnabled() && prmRtx.temporalSampling)
+    if(!isDlssEnabled() && prmRtx.temporalSampling)
     {
       int displayFrame = std::max(1, prmFrame.frameSampleId + 1);
       progress         = (float)displayFrame / (float)prmFrame.frameSampleMax;
@@ -1383,7 +1383,7 @@ void GaussianSplattingUI::onUIMenu()
     ImGui::BeginDisabled(!isRtxPipelineActive());
     // visualization mode selector
     auto visuMenu = GUI_VISUALIZE;
-    if(m_dlss.isEnabled())
+    if(isDlssEnabled())
       visuMenu = GUI_VISUALIZE_DLSS_ON;
 
     static constexpr const char* visualizeTooltip =
@@ -3418,7 +3418,7 @@ void GaussianSplattingUI::guiDrawRendererProperties()
       PE::begin("## Visualization", ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchSame);
 
       auto visuMenu = GUI_VISUALIZE;
-      if(m_dlss.isEnabled())
+      if(isDlssEnabled())
         visuMenu = GUI_VISUALIZE_DLSS_ON;
 
       ImGui::BeginDisabled(!isRtxPipelineActive());
@@ -5006,7 +5006,7 @@ void GaussianSplattingUI::guiDrawFooterBar()
       {
         float       progress = 0.0f;
         std::string buf      = "1/1";
-        if(!m_dlss.isEnabled() && prmRtx.temporalSampling)
+        if(!isDlssEnabled() && prmRtx.temporalSampling)
         {
           int displayFrame = std::max(1, prmFrame.frameSampleId + 1);  // 1-based for display
           progress         = (float)displayFrame / (float)prmFrame.frameSampleMax;

--- a/src/vkgs_project_reader.cpp
+++ b/src/vkgs_project_reader.cpp
@@ -122,9 +122,16 @@ static void loadMaterialFromJson(Material& mat, const json& matItem, int fileVer
 //--------------------------------------------------------------------------------------------------
 // Helper function to convert relative path to absolute
 //
+// Projects authored on Windows store asset paths with backslash separators
+// (e.g. "data\\scene\\cloud.ply"). On POSIX, std::filesystem treats '\\' as a
+// regular filename character, so such a path fails to resolve and the asset
+// loads empty. Normalize to '/' first; '/' is accepted on Windows too, so this
+// keeps .vkgs projects portable across platforms.
 static std::filesystem::path makeAbsolutePath(const std::filesystem::path& base, const std::string& relativePath)
 {
-  return std::filesystem::absolute(base / relativePath);
+  std::string normalized = relativePath;
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  return std::filesystem::absolute(base / normalized);
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

I tried `vk_gaussian_splatting` on AMD hardware (Radeon AI PRO R9700, RDNA4/gfx1201, RADV / Mesa 25.2.8, no NVIDIA runtime) and hit three small, unrelated issues that blocked a clean build and headless run on Linux without DLSS. This PR fixes all three; with them the raster, hardware ray tracing, and hybrid pipelines all build and render on RADV (`vkCreateRayTracingPipelinesKHR` succeeds). The changes are platform-agnostic and do not alter behavior when `USE_DLSS` is enabled.

The work is split into three focused commits so they can be reviewed (or cherry-picked) independently.

**Tested on**: base `dfb3c79` (nvpro_core2 `eb7c2f2`), LunarG Vulkan SDK 1.4.350.1, Ubuntu, headless, `-DUSE_DLSS=OFF -DDISABLE_DEFAULT_SCENE=ON`.

## Changes

### 1. Build with `-DUSE_DLSS=OFF` (no NVIDIA NGX SDK)

Two things break the build without the NGX SDK even with DLSS disabled:

- `file(GLOB SOURCE_FILES src/*.*)` unconditionally picks up `src/dlss_*.cpp` (which include NGX headers). These files are already added explicitly in the `if(USE_DLSS)` block, so the glob only ever double-adds them — excluding them from the glob is safe:

  ```cmake
  file(GLOB SOURCE_FILES src/*.*)
  list(FILTER SOURCE_FILES EXCLUDE REGEX "/dlss_")
  ```

- `m_dlss` is declared only under `#if defined(USE_DLSS)`, but `gaussian_splatting_ui.cpp` reads `m_dlss.isEnabled()` at four sites outside the guards → compile error. Added a small `isDlssEnabled()` helper that returns `false` when compiled without DLSS, and used it at those sites:

  ```cpp
  inline bool isDlssEnabled() const
  {
  #if defined(USE_DLSS)
    return m_dlss.isEnabled();
  #else
    return false;
  #endif
  }
  ```

### 2. Portable asset paths in `.vkgs` projects

Sample projects store asset paths with Windows backslashes (e.g. `data\teleportour\Winter-Garden-view2.ply`). On POSIX, `std::filesystem` treats `\` as a normal filename character, so assets fail to resolve and the scene loads empty (blank render, no error). Normalizing separators to `/` in the single choke point `makeAbsolutePath()` fixes it and stays valid on Windows too:

```cpp
std::string normalized = relativePath;
std::replace(normalized.begin(), normalized.end(), '\\', '/');
return std::filesystem::absolute(base / normalized);
```

### 3. Headless `--saveImage` before the first frame

Passing `--saveImage <file>` as a bare command-line argument (outside a benchmark `SEQUENCE`) crashes with SIGSEGV: the save runs at parse time, before any frame is rendered, and the G-buffers are created lazily on the first `onResize()`, so `getAllDumpableBuffers()` dereferences not-yet-created color images. Returning an empty list when the G-buffer is still `0x0` makes it fail gracefully (the `SEQUENCE`-based path is unchanged):

```cpp
const VkExtent2D gBufSize = m_gBuffers.getSize();
if(gBufSize.width == 0 || gBufSize.height == 0)
  return buffers;  // not rendered yet
```

If you'd prefer this to *defer* the save until after the first frame rather than no-op, I'm happy to adjust — that felt like a larger behavior change than this minimal guard.

## Testing

- Builds cleanly (315/315 targets) with `-DUSE_DLSS=OFF -DDISABLE_DEFAULT_SCENE=ON` on RADV/Mesa 25.2.8 (RDNA4), LunarG SDK 1.4.350.1.
- Headless benchmark SEQUENCE: raster / RT / hybrid pipelines all produce images.
- The `.vkgs` sample project (15.3M-gaussian splat + OBJ meshes) loads and renders after the path fix.
- No NVIDIA hardware on hand to regression-test the DLSS-on path, but none of these changes affect it: the helper returns the same value under `USE_DLSS`, the glob filter is a no-op (those sources are added explicitly), and the path / `saveImage` fixes are platform-agnostic.