### PR TITLE
Skip two wasteful shader compiles at startup and shutdown

### DIFF
--- a/src/gaussian_splatting.cpp
+++ b/src/gaussian_splatting.cpp
@@ -227,13 +227,23 @@ void GaussianSplatting::onAttach(nvapp::Application* app)
   // Initialize Tonemapper
   initTonemapper();
 
-  // Request initial shader compilation
-  m_requestUpdateShaders = true;
+  // Request initial shader compilation — but skip it when a project is going to be loaded
+  // (--inputProject). The default-mesh pipeline compiled here would be thrown away as soon
+  // as the project's settings/scene are applied. The project loader arms the compile itself
+  // (reset() on success, or the failure branches in loadProjectIfNeeded()), and --inputFile /
+  // default-scene arm it via the scene-composition detector, so no compile is lost.
+  if(prmScene.projectToLoadFilename.empty())
+    m_requestUpdateShaders = true;
 };
 
 
 void GaussianSplatting::onDetach()
 {
+  // Teardown-only: prevents reset() -> processUpdateRequests(true) from recompiling the
+  // emptied scene just before deinitShaders() runs below. Runtime reset() calls never set
+  // this, so they still recompile.
+  m_isShuttingDown = true;
+
   vkDeviceWaitIdle(m_device);
 
   // stops the threads
@@ -1378,7 +1388,7 @@ void GaussianSplatting::processUpdateRequests(bool forceAll)
   resetFrameCounter();
   vkDeviceWaitIdle(m_device);
 
-  if(m_requestUpdateShaders)
+  if(m_requestUpdateShaders && !m_isShuttingDown)
   {
     deinitPipelines();
     deinitShaders();

--- a/src/gaussian_splatting.h
+++ b/src/gaussian_splatting.h
@@ -400,6 +400,10 @@ protected:
 
   // Trigger a rebuild of the shaders and pipelines at next frame
   bool m_requestUpdateShaders = false;
+  // Teardown-only guard (set in onDetach): skips the reset() shader recompile of the
+  // emptied scene right before deinitShaders() destroys the modules. Must stay false during
+  // runtime reset()/project-switch so those still recompile.
+  bool m_isShuttingDown = false;
   // Defer shader rebuild until camera animation completes
   bool m_requestUpdateShadersAfterCameraAnim = false;
   // Track scene composition for RTX_HAS_MESHES / RTX_HAS_PARTICLES macro changes

--- a/src/gaussian_splatting_ui.cpp
+++ b/src/gaussian_splatting_ui.cpp
@@ -5686,6 +5686,9 @@ bool GaussianSplattingUI::loadProjectIfNeeded()
         LOGE("Error: unable to open project file %s\n", path.c_str());
         prmScene.projectToLoadFilename = "";
         prmScene.projectLoadPorcelain  = false;
+        // onAttach may have skipped the initial compile because a project was queued; arm it
+        // now so a failed load still renders the (empty) scene instead of a black viewport.
+        m_requestUpdateShaders = true;
         return false;
       }
 
@@ -5698,6 +5701,8 @@ bool GaussianSplattingUI::loadProjectIfNeeded()
         LOGE("Error: invalid project file %s\n", path.c_str());
         prmScene.projectToLoadFilename = "";
         prmScene.projectLoadPorcelain  = false;
+        // See note above: arm the compile so a failed load isn't a black viewport.
+        m_requestUpdateShaders = true;
         return false;
       }
       i.close();
@@ -5729,6 +5734,9 @@ bool GaussianSplattingUI::loadProjectIfNeeded()
   {
     prmScene.projectToLoadFilename = "";
     prmScene.projectLoadPorcelain  = false;
+    // reset() (pass 1) already armed the compile; keep it armed defensively so any
+    // project-load failure guarantees a shader build (never a black viewport).
+    m_requestUpdateShaders = true;
     return false;
   }
 


### PR DESCRIPTION
> Re-opens #35 — it was auto-closed when our fork was replaced during a repo
> restructure. Same single commit, no code change; re-submitting from a fresh
> fork. Original: #35

## What
Skip two redundant shader/pipeline compilations in the app lifecycle:

- **Startup**: when `--inputProject` is set, don't compile the default-mesh
  pipeline in `onAttach()` — it is immediately discarded once the project's
  settings/scene are applied. The project loader arms the compile itself
  (`reset()` on success; the guarded failure branches in `loadProjectIfNeeded()`),
  and `--inputFile` / default-scene arm it via the scene-composition detector,
  so no compile is lost.
- **Shutdown**: a teardown-only `m_isShuttingDown` guard stops
  `reset() -> processUpdateRequests(true)` from recompiling the just-emptied
  scene right before `deinitShaders()` destroys the modules.

## Why
Removes two wasteful shader-compile passes → faster cold start and cleaner
shutdown. No runtime behavior change: runtime `reset()` / project-switch still
recompile (the flag is only set in `onDetach()`).

---
 I'm contributing this as part of my work at [Maniphys-AI](https://github.com/Manifold-ai).