### PR TITLE
Enabling GS surface as shadow catcher

### DIFF
--- a/shaders/deferred_shading.comp.slang
+++ b/shaders/deferred_shading.comp.slang
@@ -138,7 +138,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     // Apply lighting from each light source (no shadows in pure rasterization)
     for(uint i = 0; i < assets.lightCount; ++i)
     {
-      if(assets.lights[i].enabled == 0)
+      if(assets.lights[i].enabled == 0 || assets.lights[i].shadowOnly != 0)
         continue;
       bool inShadow = false;  // No shadow rays in rasterization
       wavefrontComputeShadingDirectOnly(assets.lights[i], worldPos, normal, mat, viewDir, inShadow, float3(1.0), color);

--- a/shaders/shaderio.h
+++ b/shaders/shaderio.h
@@ -396,6 +396,9 @@ struct FrameInfo
   float particleEmissiveAoRadius   = 0.05f;  // AO hemisphere sampling radius
   float particleEmissiveAoStrength = 1.0f;   // AO darkening intensity (0 = no effect, 1 = full, >1 = exaggerated)
 
+  // GS shadow mask: visibility floor for shadow-only lights masking splat emissive
+  float gsShadowMaskMin = 0.2f;  // 0 = shadows go fully black, 1 = no visible shadow
+
   // Depth iso threshold: transmittance threshold for depth picking
   // Depth is picked when transmittance drops below this threshold
   float depthIsoThreshold    = 0.7f;  // For rasterization

--- a/shaders/shading.h
+++ b/shaders/shading.h
@@ -128,6 +128,8 @@ struct LightSource
   int       enabled         = 1;                       // 0=disabled, 1=enabled
   int       shadowOnly      = 0;                       // 1 = gs-shadow light: only casts shadow-mask rays onto
                                                        // splat emissive, never contributes illumination (NEE skips it)
+  int       castOnGs        = 0;                       // 1 = light illuminates AND also casts onto the GS shadow
+                                                       // mask (a lit light whose shadow darkens splat emissive)
 };
 
 #ifdef __cplusplus

--- a/shaders/shading.h
+++ b/shaders/shading.h
@@ -126,6 +126,8 @@ struct LightSource
   int       attenuationMode = 2;                       // 0=None, 1=Linear, 2=Quadratic, 3=Physical
   float     radius          = 1.0f;                    // Light source radius for soft shadows (from proxyScale)
   int       enabled         = 1;                       // 0=disabled, 1=enabled
+  int       shadowOnly      = 0;                       // 1 = gs-shadow light: only casts shadow-mask rays onto
+                                                       // splat emissive, never contributes illumination (NEE skips it)
 };
 
 #ifdef __cplusplus

--- a/shaders/shading.h.slang
+++ b/shaders/shading.h.slang
@@ -581,7 +581,9 @@ NEESample sampleOneLightNEE(in float3                     worldPos,
     int         lightIdx = min(int(rand(seed) * float(lightCount)), lightCount - 1);
     LightSource light    = lights[lightIdx];
 
-    if(light.enabled == 0)
+    // Disabled and shadow-only (gs-shadow) lights contribute no illumination.
+    // Returning a zero sample keeps the estimator unbiased (same as enabled==0).
+    if(light.enabled == 0 || light.shadowOnly != 0)
       return result;
 
     float3 lightDir;

--- a/shaders/threedgrt_raytrace.rgen.slang
+++ b/shaders/threedgrt_raytrace.rgen.slang
@@ -1420,10 +1420,11 @@ void evaluateLightingAndShadingParticles(in int           bounce,
   }
 #endif
 
-  // GS shadow mask: shadow-only (gs-shadow) lights darken the emissive term at the
-  // surfel. Same rationale as the AO block above: the emissive term has no other
-  // occlusion, while shaded contributions get their shadows from NEE shadow rays
-  // (gs-shadow lights are skipped by NEE, so nothing is counted twice).
+  // GS shadow mask: shadow-only (gs-shadow) AND castOnGs lights darken the emissive
+  // term at the surfel. The emissive term has no other occlusion; shaded contributions
+  // get their shadows from NEE shadow rays. No double-count: a shadow-only light is
+  // skipped by NEE (mask only), and a castOnGs light shadows the EMISSIVE term here and
+  // the separate NEE-shaded term via its own NEE ray -- different terms, each once.
 #if GS_SHADOW_MASK
   emissiveContribution *= computeGsShadowMask(pixel.isoSurfPos, pixel.integratedNormal, seedRayPass, payload);
 #endif
@@ -1697,6 +1698,11 @@ float computeSplatEmissiveAO(in float3 surfacePos, in float3 surfaceNormal, in f
 // Returns 1.0 when no shadow-only light reaches the surfel.
 float3 computeGsShadowMask(in float3 surfPos, in float3 surfNormal, inout uint seed, inout HitPayload payload)
 {
+  // Intensity*luminance-weighted average of per-light visibility over all mask-casting
+  // lights (shadowOnly or castOnGs). A bright castOnGs light carries a large illumination
+  // intensity, so mixing it with a dim dedicated shadow-only light lets the bright one
+  // dominate the blend -- for an independent hard-mask light, match intensities or use
+  // shadow-only lights alone.
   float3 maskSum   = float3(0.0);
   float  weightSum = 0.0;
 

--- a/shaders/threedgrt_raytrace.rgen.slang
+++ b/shaders/threedgrt_raytrace.rgen.slang
@@ -1420,6 +1420,14 @@ void evaluateLightingAndShadingParticles(in int           bounce,
   }
 #endif
 
+  // GS shadow mask: shadow-only (gs-shadow) lights darken the emissive term at the
+  // surfel. Same rationale as the AO block above: the emissive term has no other
+  // occlusion, while shaded contributions get their shadows from NEE shadow rays
+  // (gs-shadow lights are skipped by NEE, so nothing is counted twice).
+#if GS_SHADOW_MASK
+  emissiveContribution *= computeGsShadowMask(pixel.isoSurfPos, pixel.integratedNormal, seedRayPass, payload);
+#endif
+
   // Early exit for pure emissive materials - no lighting interaction
   // No clay mode in pure emissive
   if(splatSetDesc.material.needShading != 1)
@@ -1678,6 +1686,57 @@ float computeSplatEmissiveAO(in float3 surfacePos, in float3 surfaceNormal, in f
   return 1.0;
 }
 #endif  // PARTICLE_AO_ENABLED
+
+#if GS_SHADOW_MASK
+// GS shadow mask: weighted-average visibility of the surfel toward all shadow-only
+// (gs-shadow) lights, remapped through the gsShadowMaskMin floor. Occluders are
+// meshes by default; particles opt in via GS_SHADOW_MASK_PARTICLES (the receiving
+// splat set then occludes itself — use with care). Baked radiance approximates the
+// sum of all incident lighting, so per-light visibilities are averaged weighted by
+// light importance (not multiplied): overlapping shadows do not double-darken.
+// Returns 1.0 when no shadow-only light reaches the surfel.
+float3 computeGsShadowMask(in float3 surfPos, in float3 surfNormal, inout uint seed, inout HitPayload payload)
+{
+  float3 maskSum   = float3(0.0);
+  float  weightSum = 0.0;
+
+  for(uint i = 0; i < assets.lightCount; ++i)
+  {
+    LightSource light = assets.lights[i];
+    if(light.enabled == 0 || light.shadowOnly == 0)
+      continue;
+
+    // Direction/distance to the light; with SHADOWS_SOFT and radius > 0 this
+    // jitters on the light disk, converging over temporal accumulation.
+    float3 lightDir;
+    float  lightDist;
+    if(!computeLightToSurfaceVector(light, surfPos, seed, lightDir, lightDist))
+      continue;  // out of range: the light does not reach this surfel, no vote
+
+    const float3 shadowOrigin = surfPos + surfNormal * frameInfo.rtxSecondaryRayOffset;
+
+    float3 visibility = float3(1.0);
+#if RTX_HAS_MESHES
+    if(assets.meshCount > 0)
+      visibility *= traceShadowRayMesh(assets, shadowOrigin, lightDir, lightDist, payload).transmittance;
+#endif
+#if GS_SHADOW_MASK_PARTICLES && RTX_HAS_PARTICLES
+    if(maxComponent(visibility) > 0.001 && assets.totalGlobalSplatCount > 0)
+      visibility *= traceShadowRayParticle(frameInfo, assets, shadowOrigin, lightDir, lightDist, payload).transmittance;
+#endif
+
+    const float weight = max(light.intensity, 0.0) * luminance(light.color);
+    maskSum += weight * visibility;
+    weightSum += weight;
+  }
+
+  if(weightSum <= 0.0)
+    return float3(1.0);
+
+  const float3 mask = maskSum / weightSum;
+  return float3(frameInfo.gsShadowMaskMin) + (1.0 - frameInfo.gsShadowMaskMin) * mask;
+}
+#endif  // GS_SHADOW_MASK
 
 // Trace shadow ray for a single light and compute transmission
 ShadowInfo traceShadowRayForLight(in FrameInfo     frameInfo,

--- a/shaders/threedgrt_raytrace.rgen.slang
+++ b/shaders/threedgrt_raytrace.rgen.slang
@@ -1703,7 +1703,8 @@ float3 computeGsShadowMask(in float3 surfPos, in float3 surfNormal, inout uint s
   for(uint i = 0; i < assets.lightCount; ++i)
   {
     LightSource light = assets.lights[i];
-    if(light.enabled == 0 || light.shadowOnly == 0)
+    // Include shadow-only lights (mask-only) AND lit lights flagged castOnGs (illuminate + cast on GS).
+    if(light.enabled == 0 || (light.shadowOnly == 0 && light.castOnGs == 0))
       continue;
 
     // Direction/distance to the light; with SHADOWS_SOFT and radius > 0 this

--- a/shaders/threedmesh_raster.frag.slang
+++ b/shaders/threedmesh_raster.frag.slang
@@ -97,7 +97,7 @@ FragmentOutput main(FragmentInput input
     // Apply lighting from each light source (using bindless lights)
     for(int i = 0; i < assets.lightCount; ++i)
     {
-      if(assets.lights[i].enabled == 0)
+      if(assets.lights[i].enabled == 0 || assets.lights[i].shadowOnly != 0)
         continue;
       bool inShadow = false;  // Rasterization doesn't have shadow rays (yet)
       wavefrontComputeShadingDirectOnly(assets.lights[i], input.worldPos, shadingNrm, material, input.viewDir, inShadow, float3(1.0), color);

--- a/src/gaussian_splatting.cpp
+++ b/src/gaussian_splatting.cpp
@@ -429,9 +429,9 @@ void GaussianSplatting::onPreRender()
     // environment lighting, non-full-pass tracing (RTX only), or stochastic raster (raster only)
     if(prmRtx.temporalSamplingMode == TEMPORAL_SAMPLING_AUTO
        && (m_assets.cameras.getCamera().dofMode != DOF_DISABLED
-           || (prmRender.shadowsMode == ShadowsMode::eShadowsSoft && isRtxPipelineActive() && prmRender.lightingEnabled)
-           || (m_sky.isEnabled() && m_sky.mode() != shaderio::EnvironmentMode::eNone && prmRender.lightingEnabled)
-           || (isRtxPipelineActive() && prmRender.lightingEnabled)
+           || (prmRender.shadowsMode == ShadowsMode::eShadowsSoft && isRtxPipelineActive() && effectiveLightingMode())
+           || (m_sky.isEnabled() && m_sky.mode() != shaderio::EnvironmentMode::eNone && effectiveLightingMode())
+           || (isRtxPipelineActive() && effectiveLightingMode())
            || (isRtxPipelineActive() && prmRtx.rtxTraceStrategy != RTX_TRACE_STRATEGY_FULL_ANYHIT)
            || (isRasterPipelineActive() && prmRaster.sortingMethod == SORTING_STOCHASTIC_SPLAT)))
     {
@@ -1700,6 +1700,9 @@ void GaussianSplatting::updateAndUploadFrameInfoUBO(VkCommandBuffer cmd, const u
   prmFrame.particleEmissiveAoRadius   = prmRtx.particleEmissiveAoRadius;
   prmFrame.particleEmissiveAoStrength = prmRtx.particleEmissiveAoStrength;
 
+  // GS shadow mask floor
+  prmFrame.gsShadowMaskMin = prmRender.gsShadowMaskMin;
+
   // Depth iso threshold (transmittance threshold for depth picking)
   prmFrame.depthIsoThreshold    = prmRaster.depthIsoThreshold;
   prmFrame.depthIsoThresholdRTX = prmRtx.depthIsoThresholdRTX;
@@ -2319,8 +2322,13 @@ void GaussianSplatting::updateSlangMacros()
           // Normal computation method
           {"NORMAL_METHOD", std::to_string((int)prmRender.normalMethod)},
           // Global lighting, shadows, and DOF modes
-          {"LIGHTING_MODE", std::to_string(prmRender.lightingEnabled)},
+          {"LIGHTING_MODE", std::to_string(effectiveLightingMode())},
           {"SHADOWS_MODE", std::to_string((int)prmRender.shadowsMode)},
+          // GS shadow mask: gs-shadow lights darken the splat emissive at the surfel.
+          // Needs at least one occluder source compiled (meshes by default, particles opt-in).
+          {"GS_SHADOW_MASK", std::to_string((int)(prmRender.gsShadowMask
+                                                  && (!m_assets.meshes.instances.empty() || prmRender.gsShadowMaskFromParticles)))},
+          {"GS_SHADOW_MASK_PARTICLES", std::to_string((int)(prmRender.gsShadowMask && prmRender.gsShadowMaskFromParticles))},
           {"DOF_MODE", std::to_string((int)(m_assets.cameras.getCamera().dofMode))},
           // Surface info needed for lighting, DLSS, or DOF
           {"NEED_SURFACE_INFO", std::to_string((int)needSurfaceInfo())},
@@ -2353,7 +2361,7 @@ void GaussianSplatting::updateSlangMacros()
              return prmRtx.shortenRay;
            }())},
           {"PARTICLE_AO_ENABLED", std::to_string((int)(prmRtx.particleEmissiveAoEnabled && !m_assets.meshes.instances.empty()
-                                                       && prmRender.lightingEnabled == LIGHTING_ENABLED))},
+                                                       && effectiveLightingMode() == LIGHTING_ENABLED))},
 #if defined(USE_DLSS)
           {"DLSS_ENABLED", std::to_string((int)m_dlss.isEnabled())},
 #else

--- a/src/gaussian_splatting.h
+++ b/src/gaussian_splatting.h
@@ -218,7 +218,8 @@ protected:
   // Must match the NEED_SURFACE_INFO shader macro computation in updateSlangMacros()
   inline bool needSurfaceInfo()
   {
-    bool need = prmRender.lightingEnabled || (m_assets.cameras.getCamera().dofMode != DOF_DISABLED);
+    bool need = prmRender.lightingEnabled || prmRender.gsShadowMask
+                || (m_assets.cameras.getCamera().dofMode != DOF_DISABLED);
 #if defined(USE_DLSS)
     need = need || m_dlss.isEnabled();
 #endif

--- a/src/gaussian_splatting_ui.cpp
+++ b/src/gaussian_splatting_ui.cpp
@@ -4770,6 +4770,22 @@ void GaussianSplattingUI::guiDrawLightProperties()
     }
   }
 
+  {
+    // Redundant when the light already doesn't illuminate (shadow-only casts on GS anyway).
+    ImGui::BeginDisabled(asset->shadowOnly != 0);
+    bool castOnGs = (asset->castOnGs != 0);
+    if(PE::Checkbox("Cast shadow on splats (while lit)", &castOnGs,
+                    "The light illuminates normally AND its shadow also darkens the splat\n"
+                    "emissive via the GS shadow mask (requires \"GS shadow mask\" in Lighting\n"
+                    "and Temporal, RTX pipelines). Use to have one light both shadow meshes\n"
+                    "and cast onto the splats."))
+    {
+      asset->castOnGs = castOnGs ? 1 : 0;
+      needAssetUpdate = true;
+    }
+    ImGui::EndDisabled();
+  }
+
   // Instance properties (per-instance)
   needInstanceUpdate |= PE::DragFloat3("Translation", glm::value_ptr(instance->translation), 0.01f);
 

--- a/src/gaussian_splatting_ui.cpp
+++ b/src/gaussian_splatting_ui.cpp
@@ -1728,7 +1728,7 @@ void GaussianSplattingUI::guiDrawLightingModeSelector(bool inMenuBar)
   if(changed)
   {
     m_requestUpdateShaders = true;
-    m_tonemapperData.isActive = (prmRender.lightingEnabled == LIGHTING_ENABLED) ? 1 : 0;
+    m_tonemapperData.isActive = (effectiveLightingMode() == LIGHTING_ENABLED) ? 1 : 0;
   }
 }
 
@@ -1742,7 +1742,7 @@ void GaussianSplattingUI::guiDrawShadowsModeSelector(bool inMenuBar)
       "- Hard shadows: sharp point-sampled shadows.\n"
       "- Soft shadows: stochastic disk-sampled shadows around lights.";
 
-  bool disabled = (!prmRender.lightingEnabled || !isRtxPipelineActive());
+  bool disabled = (effectiveLightingMode() == LIGHTING_DISABLED || !isRtxPipelineActive());
 
   bool changed = false;
   if(inMenuBar)
@@ -3373,6 +3373,41 @@ void GaussianSplattingUI::guiDrawRendererProperties()
       guiDrawLightingModeSelector(false);
       guiDrawShadowsModeSelector(false);
 
+      // GS shadow mask: shadow-only lights darken splat emissive at the surfel (RTX pipelines)
+      {
+        ImGui::BeginDisabled(!isRtxPipelineActive());
+        if(PE::Checkbox("GS shadow mask", &prmRender.gsShadowMask,
+                        "Lights marked \"GS shadow only\" cast shadows that darken the splat\n"
+                        "emissive output at the reconstructed surface (RTX pipelines only).\n"
+                        "Preserves the baked appearance of pure-emissive splat sets while\n"
+                        "compositing shadows from meshes on top.\n"
+                        "Note: implies lighting-mode compilation (meshes become PBR-shaded,\n"
+                        "tonemapper activates) and surface reconstruction."))
+        {
+          m_tonemapperData.isActive = (effectiveLightingMode() == LIGHTING_ENABLED) ? 1 : 0;
+          m_requestUpdateShaders    = true;
+          resetFrameCounter();
+        }
+
+        ImGui::BeginDisabled(!prmRender.gsShadowMask);
+        if(PE::SliderFloat("Shadow mask min", &prmRender.gsShadowMaskMin, 0.0f, 1.0f, "%.2f", 0,
+                           "Shadow floor: 0 = shadows go fully black, 1 = no visible shadow."))
+        {
+          resetFrameCounter();
+        }
+        if(PE::Checkbox("Mask particle occluders", &prmRender.gsShadowMaskFromParticles,
+                        "Also let Gaussian particles occlude the shadow-mask rays.\n"
+                        "Warning: the receiving splat set occludes itself (large areas may\n"
+                        "darken incorrectly) and baked radiance already contains self-shadowing.\n"
+                        "Default off: only meshes cast onto the splat emissive."))
+        {
+          m_requestUpdateShaders = true;
+          resetFrameCounter();
+        }
+        ImGui::EndDisabled();
+        ImGui::EndDisabled();
+      }
+
       if(PE::entry(
              "Temporal sampling",
              [&]() { return m_ui.enumCombobox(GUI_TEMPORAL_SAMPLING, "##ID", &prmRtx.temporalSamplingMode); },
@@ -3762,7 +3797,7 @@ void GaussianSplattingUI::guiDrawRasterizationProperties()
     {
       PE::begin("## Shading", ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchSame);
 
-      ImGui::BeginDisabled(!prmRender.lightingEnabled);
+      ImGui::BeginDisabled(effectiveLightingMode() == LIGHTING_DISABLED);
       {
         if(PE::Checkbox("Quantize Normals", &prmRaster.quantizeNormals,
                         "Use octahedral encoding for normals (Meyer et al. 2010).\n"
@@ -3771,7 +3806,8 @@ void GaussianSplattingUI::guiDrawRasterizationProperties()
           m_requestUpdateShaders = true;
         }
 
-        const bool ftbDisabled = !prmRender.lightingEnabled || (prmRaster.sortingMethod == SORTING_STOCHASTIC_SPLAT);
+        const bool ftbDisabled =
+            (effectiveLightingMode() == LIGHTING_DISABLED) || (prmRaster.sortingMethod == SORTING_STOCHASTIC_SPLAT);
         ImGui::BeginDisabled(ftbDisabled);
         if(PE::entry(
                "FTB Sync Mode", [&]() { return m_ui.enumCombobox(GUI_FTB_SYNC_MODE, "##ID", &prmRaster.ftbSyncMode); },
@@ -4718,6 +4754,19 @@ void GaussianSplattingUI::guiDrawLightProperties()
     {
       asset->enabled  = enabled ? 1 : 0;
       needAssetUpdate = true;
+    }
+  }
+
+  {
+    bool shadowOnly = (asset->shadowOnly != 0);
+    if(PE::Checkbox("GS shadow only", &shadowOnly,
+                    "gs-shadow light: only casts shadow-mask rays onto splat emissive\n"
+                    "(requires \"GS shadow mask\" in Lighting and Temporal, RTX pipelines).\n"
+                    "Never contributes illumination to meshes or shaded splat sets.\n"
+                    "Tip: keep Radius = 0 for noise-free hard shadows."))
+    {
+      asset->shadowOnly = shadowOnly ? 1 : 0;
+      needAssetUpdate   = true;
     }
   }
 

--- a/src/light_manager_vk.cpp
+++ b/src/light_manager_vk.cpp
@@ -473,6 +473,7 @@ void LightManagerVk::rebuildBuffer()
       shaderLight.attenuationMode = instance->lightSource->attenuationMode;
       shaderLight.radius          = instance->lightSource->radius;
       shaderLight.enabled         = instance->lightSource->enabled;
+      shaderLight.shadowOnly      = instance->lightSource->shadowOnly;
       shaderLights.push_back(shaderLight);
     }
   }
@@ -527,6 +528,7 @@ void LightManagerVk::updateBuffer()
       shaderLight.attenuationMode = instance->lightSource->attenuationMode;
       shaderLight.radius          = instance->lightSource->radius;
       shaderLight.enabled         = instance->lightSource->enabled;
+      shaderLight.shadowOnly      = instance->lightSource->shadowOnly;
       shaderLights.push_back(shaderLight);
     }
   }

--- a/src/light_manager_vk.cpp
+++ b/src/light_manager_vk.cpp
@@ -474,6 +474,7 @@ void LightManagerVk::rebuildBuffer()
       shaderLight.radius          = instance->lightSource->radius;
       shaderLight.enabled         = instance->lightSource->enabled;
       shaderLight.shadowOnly      = instance->lightSource->shadowOnly;
+      shaderLight.castOnGs        = instance->lightSource->castOnGs;
       shaderLights.push_back(shaderLight);
     }
   }
@@ -529,6 +530,7 @@ void LightManagerVk::updateBuffer()
       shaderLight.radius          = instance->lightSource->radius;
       shaderLight.enabled         = instance->lightSource->enabled;
       shaderLight.shadowOnly      = instance->lightSource->shadowOnly;
+      shaderLight.castOnGs        = instance->lightSource->castOnGs;
       shaderLights.push_back(shaderLight);
     }
   }

--- a/src/light_manager_vk.h
+++ b/src/light_manager_vk.h
@@ -58,6 +58,7 @@ struct LightSourceVk
   float               radius          = 1.0f;   // Light source radius (soft shadows + proxy visualization)
   int                 enabled         = 1;      // 0=disabled, 1=enabled
   int                 shadowOnly      = 0;      // 1 = gs-shadow light: shadow-mask only, no illumination
+  int                 castOnGs        = 0;      // 1 = light illuminates AND also casts onto the GS shadow mask
 
   // C++ management data (NOT uploaded to GPU)
   std::shared_ptr<MeshVk> proxyMesh;      // Visualization mesh (sphere/cone/quad)

--- a/src/light_manager_vk.h
+++ b/src/light_manager_vk.h
@@ -57,6 +57,7 @@ struct LightSourceVk
   int                 attenuationMode = 2;      // 0=None, 1=Linear, 2=Quadratic, 3=Physical
   float               radius          = 1.0f;   // Light source radius (soft shadows + proxy visualization)
   int                 enabled         = 1;      // 0=disabled, 1=enabled
+  int                 shadowOnly      = 0;      // 1 = gs-shadow light: shadow-mask only, no illumination
 
   // C++ management data (NOT uploaded to GPU)
   std::shared_ptr<MeshVk> proxyMesh;      // Visualization mesh (sphere/cone/quad)

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -144,6 +144,12 @@ void registerCommandLineParameters(nvutils::ParameterRegistry* parameterRegistry
                          (int32_t)LIGHTING_DISABLED, (int32_t)LIGHTING_ENABLED);
   parameterRegistry->add({"shadowMode", "0=off(default) 1=hard shadows 2=soft shadows"},
                          (uint32_t*)&prmRender.shadowsMode, (uint32_t)SHADOWS_DISABLED, (uint32_t)SHADOWS_SOFT);
+  parameterRegistry->add({"gsShadowMask", "1=shadow-only (gs-shadow) lights darken splat emissive output (RTX pipelines)"},
+                         &prmRender.gsShadowMask);
+  parameterRegistry->add({"gsShadowMaskMin", "shadow mask floor in [0,1], 0=black shadows (default 0.2)"},
+                         &prmRender.gsShadowMaskMin);
+  parameterRegistry->add({"gsShadowMaskFromParticles", "1=particles also occlude gs-shadow mask rays (self-shadow risk)"},
+                         &prmRender.gsShadowMaskFromParticles);
 
   // Rasterization
   parameterRegistry->add({"sortStrategy", "particles rasterization strategy 0=GPU radix sort(default) 1=CPU async mono 2=CPU async multi 3=stochastic splat"},

--- a/src/parameters.h
+++ b/src/parameters.h
@@ -179,6 +179,13 @@ struct RenderParameters
   int32_t     lightingEnabled = LIGHTING_DISABLED;              // Enable lighting for all models
   ShadowsMode shadowsMode     = ShadowsMode::eShadowsDisabled;  // Shadows mode for all models (RTX only)
 
+  // GS shadow mask: shadow-only (gs-shadow) lights darken the splat emissive output
+  // at the reconstructed surfel (RTX pipelines only). Implies LIGHTING_MODE compilation
+  // and surface reconstruction; pure-emissive splat sets keep their baked appearance.
+  bool  gsShadowMask              = false;  // master enable
+  float gsShadowMaskMin           = 0.2f;   // shadow floor: 0 = shadows go black, 1 = no visible shadow
+  bool  gsShadowMaskFromParticles = false;  // also let particles occlude mask rays (self-shadow risk)
+
   // Color buffer format
   VkFormat colorFormat = VK_FORMAT_R32G32B32A32_SFLOAT;
 
@@ -194,6 +201,15 @@ struct RenderParameters
 
 // Parameters common to all rendering pipelines
 extern RenderParameters prmRender;
+
+// Effective lighting compile mode: the GS shadow mask needs the particle shading
+// path (and its linear-space/tonemapper contract) compiled in, so enabling it
+// implies LIGHTING_ENABLED even when the user keeps lighting off. Pure-emissive
+// splat sets still early-exit and keep their baked appearance.
+inline int32_t effectiveLightingMode()
+{
+  return (prmRender.lightingEnabled == LIGHTING_ENABLED || prmRender.gsShadowMask) ? LIGHTING_ENABLED : LIGHTING_DISABLED;
+}
 
 // Parameters that control rasterization
 struct RasterParameters

--- a/src/vkgs_project_reader.cpp
+++ b/src/vkgs_project_reader.cpp
@@ -803,6 +803,8 @@ void VkgsProjectReader::loadLights(const json& data, int fileVersion, GaussianSp
             LOAD1(instance->lightSource->enabled, assetItem, "enabled");
           // Optional key (feat/shadow-mask); absent in older files -> default 0
           LOAD1(instance->lightSource->shadowOnly, assetItem, "shadowOnly");
+          // Optional key (feat/gs-shadow-both-light); absent in older files -> default 0
+          LOAD1(instance->lightSource->castOnGs, assetItem, "castOnGs");
         }
         else  // Version 3: backward compatibility
         {

--- a/src/vkgs_project_reader.cpp
+++ b/src/vkgs_project_reader.cpp
@@ -234,6 +234,9 @@ void VkgsProjectReader::loadRendererSettings(const json& data, GaussianSplatting
 
   if(item.contains("shadowsMode"))
     prmRender.shadowsMode = (ShadowsMode)item["shadowsMode"].get<int>();
+  LOAD1(prmRender.gsShadowMask, item, "gsShadowMask");
+  LOAD1(prmRender.gsShadowMaskMin, item, "gsShadowMaskMin");
+  LOAD1(prmRender.gsShadowMaskFromParticles, item, "gsShadowMaskFromParticles");
   // Backward compat: old projects used bool "shadowsEnabled"
   if(!item.contains("shadowsMode") && item.contains("shadowsEnabled"))
     prmRender.shadowsMode = item["shadowsEnabled"].get<bool>() ? ShadowsMode::eShadowsHard : ShadowsMode::eShadowsDisabled;
@@ -798,6 +801,8 @@ void VkgsProjectReader::loadLights(const json& data, int fileVersion, GaussianSp
             LOAD1(instance->lightSource->radius, assetItem, "proxyScale");
           if(assetItem.contains("enabled"))
             LOAD1(instance->lightSource->enabled, assetItem, "enabled");
+          // Optional key (feat/shadow-mask); absent in older files -> default 0
+          LOAD1(instance->lightSource->shadowOnly, assetItem, "shadowOnly");
         }
         else  // Version 3: backward compatibility
         {

--- a/src/vkgs_project_writer.cpp
+++ b/src/vkgs_project_writer.cpp
@@ -153,6 +153,9 @@ void VkgsProjectWriter::saveRendererSettings(json& data, const GaussianSplatting
 #endif
   item["lightingEnabled"]                      = (prmRender.lightingEnabled != 0);
   item["shadowsMode"]                          = (int)prmRender.shadowsMode;
+  item["gsShadowMask"]                         = prmRender.gsShadowMask;
+  item["gsShadowMaskMin"]                      = prmRender.gsShadowMaskMin;
+  item["gsShadowMaskFromParticles"]            = prmRender.gsShadowMaskFromParticles;
   item["colorFormat"]                          = (int)prmRender.colorFormat;
   item["rtxMaxBounces"]                        = prmFrame.rtxMaxBounces;
   item["rtxSecondaryRayOffset"]                = prmFrame.rtxSecondaryRayOffset;
@@ -264,6 +267,7 @@ void VkgsProjectWriter::saveLights(json& data, const GaussianSplattingUI* ui)
       assetItem["attenuationMode"] = instance->lightSource->attenuationMode;
       assetItem["radius"]          = instance->lightSource->radius;
       assetItem["enabled"]         = instance->lightSource->enabled;
+      assetItem["shadowOnly"]      = instance->lightSource->shadowOnly;
 
       assetsArray.push_back(assetItem);
     }

--- a/src/vkgs_project_writer.cpp
+++ b/src/vkgs_project_writer.cpp
@@ -268,6 +268,7 @@ void VkgsProjectWriter::saveLights(json& data, const GaussianSplattingUI* ui)
       assetItem["radius"]          = instance->lightSource->radius;
       assetItem["enabled"]         = instance->lightSource->enabled;
       assetItem["shadowOnly"]      = instance->lightSource->shadowOnly;
+      assetItem["castOnGs"]        = instance->lightSource->castOnGs;
 
       assetsArray.push_back(assetItem);
     }


### PR DESCRIPTION
## Summary

VKGS multiplies shadows onto the NEE lighting term only, so a purely emissive radiance field (the default splat material) receives no cast shadows at all. This PR closes that gap without altering the baked appearance: a mesh occluder's shadow is masked directly onto the 3DGS emissive output at the reconstructed iso-opacity surfel — a radiance-field analogue of a *shadow catcher*, with no proxy geometry.

## What's in it

`computeGsShadowMask` (`threedgrt_raytrace.rgen.slang`, modeled on `computeSplatEmissiveAO`):

- Per `shadowOnly` / `castOnGs` light, traces a shadow ray from the surfel and combines visibility as an intensity·luminance-weighted average — overlapping shadows don't compound / double-darken.
- Remaps through the `gsShadowMaskMin` floor (`min + (1 - min)·mask`) and multiplies into the emissive term before the `needShading` early-exit, so purely-emissive splat sets are covered too.
- Occluders are meshes by default (`traceShadowRayMesh`; transmissive meshes cast colored shadows). Particles opt in via `gsShadowMaskFromParticles` (receiver self-shadow risk).

### Two per-light modes

- **Cast-on-GS** (`castOnGs`) — an orthogonal flag on an illuminating light so its shadow also darkens the splat emissive. One light can then both shade meshes via NEE and cast onto the GS. Ignored when `shadowOnly` is set.
- **Shadow-only** (`shadowOnly`) — casts shadows but never illuminates. Skipped by NEE (`sampleOneLightNEE`) and every direct-light loop (deferred / mesh raster) following the existing `enabled == 0` precedent (unbiased); only traces shadow-mask rays.

### New render options (CLI + `.vkgs` + GUI)

- `gsShadowMask` — enable the mask (RTX pipelines).
- `gsShadowMaskMin` — shadow floor in `[0, 1]`, default `0.2` (`0` = full black).
- `gsShadowMaskFromParticles` — let particles also occlude the mask rays.
- `forceSurfel` — force splat surface reconstruction even when lighting is off.
- `effectiveLightingMode()` makes `gsShadowMask` imply `LIGHTING_MODE = 1` (shared helper; tonemapper / temporal / AO / gating consumers updated).

## Scope & limitations

- RTX pipelines 2/3/5 only — raster deferred shading has no ray-query path.
- Enabling the mask implies lighting mode (mesh → PBR shading, tonemapper active) — the same side effects as turning lighting on manually.
- Soft shadows (radius > 0 + `SHADOWS_SOFT`) need temporal accumulation to converge; radius = 0 gives zero-noise hard shadows.

## Compatibility

- The `LightSource` GPU struct gains `shadowOnly` and `castOnGs` as trailing fields, preserving all existing offsets.

## Testing

Exercised on RTX hardware with a shadow-catcher scene (pipeline 2 + `gsShadowMask`):

- A mesh occluder casts onto an emissive splat set with the baked appearance otherwise unchanged; `gsShadowMaskMin` and hard/soft modes behave as described.
- Splat sets playing as shadow occluders haven't been fully tested.

---

I'm contributing this as part of my work at [Maniphys-AI](https://github.com/Manifold-ai).
