### PR TITLE
fix: FTB pipeline attachment counts and storage-image synchronisation

### DIFF
--- a/src/gaussian_splatting.cpp
+++ b/src/gaussian_splatting.cpp
@@ -2859,10 +2859,16 @@ void GaussianSplatting::initPipelines()
       }
       // Note: For FTB, depth buffer is not a color attachment - it's accessed via storage image
 
-      // Add blend state for splat ID buffer (fourth color attachment) - NO blending, just write
-      pipelineState.colorBlendEnables.push_back(VK_FALSE);                // No blending for integer ID
-      pipelineState.colorWriteMasks.push_back(VK_COLOR_COMPONENT_R_BIT);  // Single component for uint32
-      pipelineState.colorBlendEquations.push_back({});                    // Unused but required
+      // Add blend state for splat ID buffer - NO blending, just write.
+      // Not an attachment in FTB, where the id is written as a storage image: the blend state is
+      // sized from colorWriteMasks, so an entry here that colorFormats does not match makes
+      // attachmentCount disagree with the pipeline's colour attachment count.
+      if(!useFTB)
+      {
+        pipelineState.colorBlendEnables.push_back(VK_FALSE);                // No blending for integer ID
+        pipelineState.colorWriteMasks.push_back(VK_COLOR_COMPONENT_R_BIT);  // Single component for uint32
+        pipelineState.colorBlendEquations.push_back({});                    // Unused but required
+      }
     }
 
     // By default disable depth write and test for the pipeline
@@ -2962,8 +2968,8 @@ void GaussianSplatting::initPipelines()
         if(!useFTB)
         {
           creator.colorFormats.push_back(m_rasterDepthFormat);
+          creator.colorFormats.push_back(m_splatIdFormat);
         }
-        creator.colorFormats.push_back(m_splatIdFormat);
       }
       creator.renderingState.depthAttachmentFormat = m_depthFormat;
       creator.dynamicStateValues.push_back(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
@@ -3008,10 +3014,13 @@ void GaussianSplatting::initPipelines()
         pipelineState.colorBlendEquations.push_back({});
       }
 
-      // Splat ID buffer - no blending, no write
-      pipelineState.colorBlendEnables.push_back(VK_FALSE);
-      pipelineState.colorWriteMasks.push_back(0);
-      pipelineState.colorBlendEquations.push_back({});
+      // Splat ID buffer - no blending, no write. Absent in FTB, as above.
+      if(!useFTB)
+      {
+        pipelineState.colorBlendEnables.push_back(VK_FALSE);
+        pipelineState.colorWriteMasks.push_back(0);
+        pipelineState.colorBlendEquations.push_back({});
+      }
     }
 
     // TODOC
@@ -3055,8 +3064,8 @@ void GaussianSplatting::initPipelines()
       if(!useFTB)
       {
         creator.colorFormats.push_back(m_rasterDepthFormat);
+        creator.colorFormats.push_back(m_splatIdFormat);
       }
-      creator.colorFormats.push_back(m_splatIdFormat);
     }
     creator.renderingState.depthAttachmentFormat = m_depthFormat;
     creator.dynamicStateValues.push_back(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
@@ -3111,18 +3120,20 @@ void GaussianSplatting::initPipelines()
     pipelineStateDepth.depthStencilState.depthWriteEnable = VK_TRUE;
     pipelineStateDepth.depthStencilState.depthCompareOp   = VK_COMPARE_OP_LESS;  // Write if closer than existing
 
-    // Disable color writes for all attachments (depth-only pass)
-    // Must match render pass color attachment count: main + normal + splatId = 3
-    // All arrays must have matching sizes
-    VkColorBlendEquationEXT noBlend{};  // Default values (no blending)
-    pipelineStateDepth.colorBlendEnables   = {VK_FALSE, VK_FALSE, VK_FALSE};
-    pipelineStateDepth.colorBlendEquations = {noBlend, noBlend, noBlend};
-    pipelineStateDepth.colorWriteMasks     = {0, 0, 0};  // No color writes
-
     nvvk::GraphicsPipelineCreator creatorDepth;
     creatorDepth.pipelineInfo.layout = m_pipelineLayout;
-    // Must match the render pass color attachments (FTB with generateSurface)
-    creatorDepth.colorFormats                         = {prmRender.colorFormat, m_normalFormat, m_splatIdFormat};
+    // Must match the render pass colour attachments, and this pipeline exists only under FTB.
+    // useFTB implies needSurfaceInfo(), so the normal buffer is always present; the splat id is
+    // not an attachment here, because FTB writes it as a storage image inside the interlock.
+    creatorDepth.colorFormats = {prmRender.colorFormat, m_normalFormat};
+
+    // Depth-only pass: no colour writes at all, one entry per attachment. Sized from the format
+    // list rather than hardcoded, so the two cannot drift apart again.
+    const size_t            depthAttachmentCount = creatorDepth.colorFormats.size();
+    VkColorBlendEquationEXT noBlend{};  // Default values (no blending)
+    pipelineStateDepth.colorBlendEnables.assign(depthAttachmentCount, VK_FALSE);
+    pipelineStateDepth.colorBlendEquations.assign(depthAttachmentCount, noBlend);
+    pipelineStateDepth.colorWriteMasks.assign(depthAttachmentCount, 0);
     creatorDepth.renderingState.depthAttachmentFormat = m_depthFormat;
 
     creatorDepth.addShader(VK_SHADER_STAGE_VERTEX_BIT, "main", m_shaders.depthConsolidateVertShader);

--- a/src/gaussian_splatting.cpp
+++ b/src/gaussian_splatting.cpp
@@ -1054,9 +1054,28 @@ void GaussianSplatting::renderHybridPipeline(VkCommandBuffer cmd, uint32_t splat
       // For FTB: depth and splat-id buffers stay in GENERAL layout (storage image access)
     }
 
-    if(!barriers.empty())
+    // In FTB the depth and splat-id buffers are written as storage images from the fragment
+    // shader, so they take no attachment barrier above -- and an image barrier naming a
+    // different image orders execution but makes neither of these writes available or visible.
+    // Both readers sit outside this pass: the deferred shading dispatch and the hybrid trace.
+    // The ray tracing stage is only a legal destination when the pipeline feature is enabled,
+    // which it need not be: the RT extensions are requested as optional in main.cpp, and FTB is
+    // reached on a raster-only device whenever needSurfaceInfo() is true.
+    const bool             needFtbStorageBarrier = useFTB && needSurfaceInfo();
+    const VkMemoryBarrier2 ftbStorageBarrier{
+        .sType         = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+        .srcStageMask  = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
+        .srcAccessMask = VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT,
+        .dstStageMask  = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
+                        | (isSupported.raytracing ? VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR : 0),
+        .dstAccessMask = VK_ACCESS_2_SHADER_STORAGE_READ_BIT,
+    };
+
+    if(!barriers.empty() || needFtbStorageBarrier)
     {
       VkDependencyInfo depInfo{.sType                   = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+                               .memoryBarrierCount      = needFtbStorageBarrier ? 1u : 0u,
+                               .pMemoryBarriers         = needFtbStorageBarrier ? &ftbStorageBarrier : nullptr,
                                .imageMemoryBarrierCount = static_cast<uint32_t>(barriers.size()),
                                .pImageMemoryBarriers    = barriers.data()};
       vkCmdPipelineBarrier2(cmd, &depInfo);


### PR DESCRIPTION
Two fixes to the front-to-back path, both stemming from `ab4cda5` ("fix: multi splat material broken in raster and hybrid").

### 1. Match every FTB pipeline to the render pass attachments

`ab4cda5` dropped the splat id from the FTB colour attachment list and updated the two mesh-shader splat pipeline creation sites — its commit message says as much. Four other pipelines bound in that same render pass still declare the format:

- `GsVert`
- `SceneMesh`
- `SceneMeshFtbColor` (copies `SceneMesh`'s formats)
- `DepthConsolidate` (hardcoded three formats, with a comment asserting the count)

Separately, the **blend state** was missed everywhere, including at the two sites that were fixed. `GraphicsPipelineCreator` derives `colorBlendState.attachmentCount` from `colorWriteMasks` (`nvvk/graphics_pipeline.cpp`), independently of `colorFormats`, so the unguarded splat-id entry in the shared pipeline state leaves `attachmentCount` one above the pipeline's colour attachment count under FTB.

`DepthConsolidate` now derives its formats and sizes its blend arrays from that list rather than hardcoding three, so the two cannot drift apart again.

Reachable whenever `needSurfaceInfo()` and non-stochastic sorting are both true — i.e. ordinary raster or hybrid rendering with lighting enabled.

### 2. Make the FTB storage-image writes visible to their readers

Under FTB the depth and splat-id buffers are written from the fragment shader as storage images, so the post-pass barrier batch skips them — they need no layout transition. But an image memory barrier scopes availability and visibility to the subresource ranges it names, so the barriers on the colour and normal images order execution without making these two writes visible.

Both readers sit outside the pass and neither has a barrier of its own: the deferred-shading dispatch, and in hybrid the ray tracing pass. The in-pass barrier `ab4cda5` added covers only `DepthConsolidate`.

The depth half predates `ab4cda5`; the splat id joined it when the write moved to a storage image.

The ray tracing destination stage is gated on `isSupported.raytracing`, since the RT extensions are requested as optional in `main.cpp` and FTB is reached on a raster-only device whenever `needSurfaceInfo()` is true — naming that stage there would break `VUID-VkMemoryBarrier2-dstStageMask-07946`.

### Verification

Compile-verified on `d0a3bef` with `-DUSE_DLSS=OFF`. **Not** confirmed against validation layers at runtime — the findings and both fixes come from reading the code and `nvvk`'s pipeline creator, so the attachment-count VUIDs and the sync hazard are reasoned rather than observed. Worth a validation run before merging.

Found while merging 2026.2.9 into a downstream fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
